### PR TITLE
DIAL discovery concurrency fixes

### DIFF
--- a/src/android/HbbTvManager.java
+++ b/src/android/HbbTvManager.java
@@ -62,6 +62,7 @@ public class HbbTvManager{
   public synchronized void discoverTerminals(){
     if(!searching){
       searching = true;
+      Log.d(TAG, "discoverTerminals: start searching");
       try {
         getHbbTvTerminals().clear();
         getDial().search(TIMEOUT);
@@ -73,6 +74,7 @@ public class HbbTvManager{
         @Override
         public void run() {
           synchronized(HbbTvManager.this) {
+            Log.d(TAG, "discoverTerminals: stop searching");
             if (getDiscoverTerminalsCallback() != null){
               getDiscoverTerminalsCallback().onDiscoverTerminals(getLastFoundTerminals());
             }
@@ -99,9 +101,11 @@ public class HbbTvManager{
       mDial = new Dial(new Dial.DeviceFoundCallback() {
         @Override
         public void onDialDeviceFound(final DialDevice dialDevice) {
+          Log.d(TAG, "onDialDeviceFound: " + dialDevice.getApplicationUrl());
           dialDevice.getAppInfo("HbbTV",new Dial.GetAppInfoCallback() {
             @Override
             public void onReceiveAppInfo(DialAppInfo appInfo) {
+              Log.d(TAG, "onReceiveAppInfo: " + dialDevice.getApplicationUrl() + ", " + appInfo);
               if(appInfo != null /*&& appInfo.getAdditionalData("X_HbbTV_App2AppURL") != null*/){
                 getHbbTvTerminals().put(dialDevice.getApplicationUrl(),appInfo);
               }

--- a/src/android/HbbTvManager.java
+++ b/src/android/HbbTvManager.java
@@ -21,6 +21,7 @@
 package de.fhg.fokus.famium.hbbtv;
 
 import android.util.Log;
+import android.os.Handler;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -40,12 +41,14 @@ public class HbbTvManager{
   private Map<String, DialAppInfo> mHbbTvTerminals;
   private DiscoverTerminalsCallback mDiscoverTerminalsCallback;
   private boolean searching = false;
+  private Handler mHandler;
   public HbbTvManager(){
 
   };
 
   public HbbTvManager(DiscoverTerminalsCallback discoverTerminalsCallback){
     mDiscoverTerminalsCallback = discoverTerminalsCallback;
+    mHandler = new Handler();
   }
 
   public DiscoverTerminalsCallback getDiscoverTerminalsCallback() {
@@ -62,20 +65,21 @@ public class HbbTvManager{
       try {
         getHbbTvTerminals().clear();
         getDial().search(TIMEOUT);
-        wait(TIMEOUT);
       }
       catch (IOException e){
         Log.e(TAG,e.getMessage(),e);
       }
-      catch (InterruptedException e){
-        Log.e(TAG,e.getMessage(),e);
-      }
-      finally {
-        if (getDiscoverTerminalsCallback() != null){
-          getDiscoverTerminalsCallback().onDiscoverTerminals(getLastFoundTerminals());
+      mHandler.postDelayed(new Runnable() {
+        @Override
+        public void run() {
+          synchronized(HbbTvManager.this) {
+            if (getDiscoverTerminalsCallback() != null){
+              getDiscoverTerminalsCallback().onDiscoverTerminals(getLastFoundTerminals());
+            }
+            searching = false;
+          }
         }
-        searching = false;
-      }
+      }, TIMEOUT);
     }
   }
 

--- a/src/android/dial/Dial.java
+++ b/src/android/dial/Dial.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import de.fhg.fokus.famium.hbbtv.ssdp.Ssdp;
 import de.fhg.fokus.famium.hbbtv.ssdp.SsdpMessage;
@@ -48,6 +50,8 @@ public class Dial {
   private DeviceFoundCallback mDeviceFoundCallback;
   private Ssdp.SsdpCallback mSsdpCallback;
   private Ssdp mSsdp;
+
+  private Executor mExecutor = Executors.newCachedThreadPool();
 
   public Dial(DeviceFoundCallback deviceFoundCallback){
     mDeviceFoundCallback = deviceFoundCallback;
@@ -99,8 +103,9 @@ public class Dial {
 
   private void getDialDevice(String deviceDescriptionUrl, SsdpMessage ssdpMessage){
     DialDevice device = new DialDevice(deviceDescriptionUrl, ssdpMessage);
+    device.setExecutor(mExecutor);
     device.setUSN(ssdpMessage.get("USN"));
-    new DownloadDeviceDescriptionTask().execute(device);
+    new DownloadDeviceDescriptionTask().executeOnExecutor(mExecutor, device);
   }
 
   public interface DeviceFoundCallback {

--- a/src/android/dial/DialDevice.java
+++ b/src/android/dial/DialDevice.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.Executor;
 
 import de.fhg.fokus.famium.hbbtv.ssdp.SsdpMessage;
 
@@ -54,6 +55,7 @@ public class DialDevice {
   private String mModelName;
   private String mUDN;
   private String mPresentationUrl;
+  private Executor mExecutor = AsyncTask.SERIAL_EXECUTOR;
 
   public DialDevice(String descriptionUrl, SsdpMessage ssdpMessage){
     mDescriptionUrl = descriptionUrl;
@@ -164,22 +166,26 @@ public class DialDevice {
   public void getAppInfo(String appName, Dial.GetAppInfoCallback getAppInfoCallback){
     if(getApplicationUrl() != null){
       DialAppInfo appInfo = new DialAppInfo(this,appName);
-      new DownloadAppInfoTask(getAppInfoCallback).execute(appInfo);
+      new DownloadAppInfoTask(getAppInfoCallback).executeOnExecutor(mExecutor, appInfo);
     }
   }
 
   public void launchApp(String appName, String launchData, String contentType, Dial.LaunchAppCallback launchAppCallback){
     if(getApplicationUrl() != null){
       String appUrl = getApplicationUrl()+appName;
-      new LaunchAppTask(launchAppCallback).execute(appUrl, launchData, contentType);
+      new LaunchAppTask(launchAppCallback).executeOnExecutor(mExecutor, appUrl, launchData, contentType);
     }
   }
 
   public void stopApp(String appName, String runId, Dial.StopAppCallback stopAppCallback){
     if(getApplicationUrl() != null){
       String stopUrl = getApplicationUrl()+appName+"/"+runId;
-      new StopAppTask(stopAppCallback).execute(stopUrl);
+      new StopAppTask(stopAppCallback).executeOnExecutor(mExecutor, stopUrl);
     }
+  }
+
+  public void setExecutor(Executor executor) {
+    mExecutor = executor;
   }
 
   private class DownloadAppInfoTask extends AsyncTask<DialAppInfo, Void, DialAppInfo> {


### PR DESCRIPTION
This PR is to fix threading issues in the implementation of DIAL device discovery.

The first fix is to no longer block the main (UI) thread whilst waiting for the discovery timeout (5s).
The second fix is to execute network requests to DIAL devices concurrently, instead of serially. This fixes discovery when a device is slow to respond to respond or unreachable, as otherwise any subsequent devices to be contacted will not be discovered within the discovery timeout.
Additionally this adds some debug logging which is useful for observing the timing of discovery events.
