### PR TITLE
HbbTV: Fix null ptr deref of statusCode in launchHbbTVApp failure path.

### DIFF
--- a/src/android/HbbTV.java
+++ b/src/android/HbbTV.java
@@ -74,7 +74,11 @@ public class HbbTV extends CordovaPlugin {
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK,statusCode));
           }
           else {
-            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR,statusCode));
+            int status = 500;
+            if (statusCode != null) {
+              status = statusCode.intValue();
+            }
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR,status));
           }
         }
       });


### PR DESCRIPTION
The code checks that statusCode is not null in the onLaunchApp
callback, but still tries to dereference it in the failure path.
If it's null use the value 500 instead.
